### PR TITLE
fixed "range" parameter in hist()

### DIFF
--- a/pyspark_dist_explore/pyspark_dist_explore.py
+++ b/pyspark_dist_explore/pyspark_dist_explore.py
@@ -136,7 +136,7 @@ def create_histogram_object(kwargs):
 
     if 'range' in kwargs:
         range = kwargs['range']
-        del kwargs[range]
+        del kwargs['range']
 
     return Histogram(bins=bins, range=range)
 


### PR DESCRIPTION
We remove the "range" param by a value, not by its name. So when used it ends with an `KeyError` exception.