### PR TITLE
Update to 'spline' name from latest SciPy version.

### DIFF
--- a/pyspark_dist_explore/pyspark_dist_explore.py
+++ b/pyspark_dist_explore/pyspark_dist_explore.py
@@ -1,4 +1,7 @@
-from scipy.interpolate import spline
+try:
+    from scipy.interpolate import spline
+except:
+    from scipy.interpolate import UnivariateSpline as spline
 
 try:
     from pyspark.sql.types import NumericType


### PR DESCRIPTION
Latest SciPy v1.3.0 does not appear to contain the 'spline' name from scipy.interpolate in v0.18.1. 'UnivariateSpline' appears as the closest proxy to achieve same result. Added code for optionality at the top respecting 'spline' name for the remainder of the code. Tested and worked for both standard and segmented-by-categorical histograms (multiple inputs).